### PR TITLE
chore(build): Backport header fix

### DIFF
--- a/armory-header-deck/package.json
+++ b/armory-header-deck/package.json
@@ -15,7 +15,7 @@
     "prepare": "husky-install"
   },
   "dependencies": {
-    "@spinnaker/core": "2021.0.0-20210927173853.release-1.27.x",
+    "@spinnaker/core": "2022.0.0-20220614170036.release-1.27.x",
     "@spinnaker/pluginsdk": "0.2.0",
     "@spinnaker/pluginsdk-peerdeps": "0.0.16",
     "@spinnaker/presentation": "0.0.5",
@@ -29,7 +29,7 @@
     "react": "16.14.0",
     "react-bootstrap": "^2.0.0-beta.4",
     "react-dom": "16.14.0",
-    "recoil": "^0.0.10",
+    "recoil": "0.7.2",
     "rxjs": "6.6.7"
   },
   "devDependencies": {

--- a/armory-header-deck/src/components/Header/ArmoryHeader.tsx
+++ b/armory-header-deck/src/components/Header/ArmoryHeader.tsx
@@ -22,7 +22,7 @@ export const ArmoryHeader = () => {
   const isApplicationView =
     currentState.name.includes('project.application.') || currentState.name.includes('applications.application.');
 
-  const [verticalNavExpanded, setVerticalNavExpanded] = useState<boolean>(false);
+  const [verticalNavExpanded, setVerticalNavExpanded] = useState<boolean>(!CollapsibleSectionStateCache.isSet('verticalNav') || CollapsibleSectionStateCache.isExpanded('verticalNav'));
   const toggleNav = () => {
     setVerticalNavExpanded(!verticalNavExpanded);
     CollapsibleSectionStateCache.setExpanded('verticalNav', !verticalNavExpanded);


### PR DESCRIPTION
Update spinnaker/core version to the latest OSS version
Backport one commit done for the 2.28.x release